### PR TITLE
Adding support fort string `queue` statements

### DIFF
--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -81,8 +81,10 @@ class Job(BaseNode):
     requirements : str or None, optional
         Additional requirements to be included in ClassAd.
 
-    queue : int or None, optional
-        Integer specifying how many times you would like this job to run.
+    queue : int, str, or None, optional
+        Either an integer specifying how many times
+        you would like this job to run, or a string to
+        append after 'queue' in the submit file.
 
     extra_lines : list or None, optional
         List of additional lines to be added to submit file.
@@ -305,9 +307,7 @@ class Job(BaseNode):
         if self.extra_lines:
             lines.extend(self.extra_lines)
 
-        # Add arguments and queue line
-        if self.queue is not None and not isinstance(self.queue, int):
-            raise ValueError('queue must be of type int')
+        # Add arguments
         # If building this submit file for a job that's being managed by DAGMan
         # just add simple arguments and queue lines
         if indag:
@@ -315,10 +315,6 @@ class Job(BaseNode):
                 lines.append('arguments = $(ARGS)')
             if self._has_arg_names:
                 lines.append('job_name = $(job_name)')
-            if self.queue:
-                lines.append('queue {}'.format(self.queue))
-            else:
-                lines.append('queue')
         else:
             if self.args and self.queue:
                 if len(self.args) > 1:
@@ -329,7 +325,6 @@ class Job(BaseNode):
                     arg = self.args[0].arg
                     lines.append('arguments = {}'.format(string_rep(arg,
                                                          quotes=True)))
-                    lines.append('queue {}'.format(self.queue))
             # Any arguments supplied will be taken care of via the queue line
             elif self.args:
                 for arg, arg_name, _ in self.args:
@@ -340,11 +335,10 @@ class Job(BaseNode):
                         lines.append('job_name = {}_{}'.format(name, arg_name))
                     else:
                         lines.append('job_name = {}'.format(name))
-                    lines.append('queue')
-            elif self.queue:
-                lines.append('queue {}'.format(self.queue))
-            else:
-                lines.append('queue')
+
+        # write queue line last, only specifying
+        # 'queue' if self.queue is None
+        lines.append(f'queue {self.queue or ""}'.rstrip())
 
         with open(submit_file, 'w') as f:
             f.writelines('\n'.join(lines))

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -90,21 +90,27 @@ def test_add_parents_type_fail(job):
         job.add_parents([1, 2, 3, 4])
 
 
-def test_queue_written_to_submit_file(tmpdir):
+@pytest.mark.parametrize('queue', [None, 5, 'arg from 1, 2, 3'])
+def test_queue_written_to_submit_file(tmpdir, queue):
     # Test to check that the queue parameter is properly written
     # to submit file when Job is created. See issue #38.
 
     submit_dir = str(tmpdir.mkdir('submit'))
 
-    # Build Job object with queue=5
-    job = Job('jobname', example_script, submit=submit_dir, queue=5)
+    # Build Job object with indicated queue command
+    job = Job('jobname', example_script, submit=submit_dir, queue=queue)
     job.build(fancyname=False)
 
-    # Read the built submit file and check that the 'queue 5' is
-    # contained in the file.
+    # Read the built submit file and check that the
+    # expecteed queue command is contained in the file.
     with open(job.submit_file, 'r') as f:
         lines = f.readlines()
-    assert 'queue 5' in lines
+
+    if queue is not None:
+        assert f'queue {queue}' in lines
+    else:
+        assert 'queue' in lines
+    
 
 
 def test_job_submit_env_variable_dir(tmpdir, monkeypatch):


### PR DESCRIPTION
Addresses #155 , adding support for strings in the `queue` argument in `Job` to enable [dynamic variable specification](https://chtc.cs.wisc.edu/uw-research-computing/multiple-jobs) in job submission.